### PR TITLE
Modernize jacks-context to use geni-lib contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ jacks-context.py -- The script itself
 
 ## Usage
 
-Make sure that you have a geni-lib config.py in the same directory as
-your script. Run it as follows:
+Make sure that you
+[create a geni-lib context](http://geni-lib.readthedocs.io/en/latest/tutorials/portalcontext.html)
+before running the generation script.
+
+Run it as follows:
 
     jacks-context.py [-h] [--config CONFIG] [--output OUTPUT] [--basic]
                             site [site ...]
@@ -25,4 +28,3 @@ your script. Run it as follows:
 * `--basic` mode ignores types and options set as advanced in the
   configuration file.
 * `site` is a geni-lib nickname for an IG aggregate (ex: ig-utah)
-

--- a/jacks-context.py
+++ b/jacks-context.py
@@ -18,6 +18,7 @@ import geni.aggregate.protogeni as PG
 import geni.aggregate.cloudlab as CL
 import geni.aggregate.apt as APT
 from geni.rspec.pgad import Advertisement
+import geni.util
 
 extra = {}
 advanced_types = []
@@ -41,7 +42,7 @@ link_info = {
 site_info = {}
 debug = False
 
-context = config.buildContext()
+context = geni.util.loadContext(key_passphrase=True)
 
 ##########################################################################
 


### PR DESCRIPTION
geni-lib now has a separate command to generate a context from
an omni.bundle. Use that capability in jacks-context to make
it similar to other modern geni-lib scripts.