### PR TITLE
Remove outdated import

### DIFF
--- a/jacks-context.py
+++ b/jacks-context.py
@@ -10,7 +10,6 @@ import sys
 import os
 import tempfile
 
-import config
 import geni.aggregate.instageni as IG
 import geni.aggregate.exogeni as EXO
 import geni.aggregate.opengeni as OG


### PR DESCRIPTION
When jacks-context was updated to use a context (from omni.bundle)
instead of a config file, an import was erroneously left behind.
Remove it.

Fixes #18 
